### PR TITLE
Padding fixes

### DIFF
--- a/sonixflasher.c
+++ b/sonixflasher.c
@@ -691,6 +691,10 @@ bool flash(hid_device *dev, long offset, const char *file_name, long fw_size, bo
             printf("Flash Verification Checksum: OK!\n");
             return true;
         } else {
+            if (offset != 0) {
+                printf("Warning: offset 0x%04lx requested. Flash Verification Checksum disabled.\n", offset);
+                return true;
+            }
             fprintf(stderr, "ERROR:Flash Verification Checksum: FAILED! response is 0x%04x, expected 0x%04x.\n", resp_16, checksum);
             return false;
         }

--- a/sonixflasher.c
+++ b/sonixflasher.c
@@ -37,6 +37,7 @@
 #define USER_ROM_PAGES_SN32F290 256
 
 #define QMK_OFFSET_DEFAULT 0x200
+#define MIN_FIRMWARE 0x100
 
 #define CMD_BASE 0x55AA
 #define CMD_GET_FW_VERSION 0x1
@@ -730,7 +731,7 @@ bool sanity_check_firmware(long fw_size, long offset) {
         fprintf(stderr, "ERROR: Firmware is too large too flash: 0x%08lx max allowed is 0x%08lx.\n", fw_size, MAX_FIRMWARE - offset);
         return false;
     }
-    if (fw_size < 0x100) {
+    if (fw_size < MIN_FIRMWARE) {
         fprintf(stderr, "ERROR: Firmware is too small.");
         return false;
     }

--- a/sonixflasher.c
+++ b/sonixflasher.c
@@ -87,6 +87,7 @@
 #define PROJECT_VER "2.0.7"
 
 uint16_t           BLANK_CHECKSUM   = 0x0000;
+uint16_t           checksum         = 0;
 uint16_t           CS0              = CS0_0;
 uint16_t           USER_ROM_SIZE    = USER_ROM_SIZE_SN32F260;
 uint16_t           USER_ROM_PAGES   = USER_ROM_PAGES_SN32F260;
@@ -656,14 +657,12 @@ bool flash(hid_device *dev, long offset, const char *file_name, long fw_size, bo
     printf("Flashing device, please wait...\n");
 
     size_t   bytes_read = 0;
-    uint16_t checksum   = 0;
     uint32_t last_chunk = 0;
     clear_buffer(buf, REPORT_SIZE);
     while ((bytes_read = fread(buf, 1, REPORT_SIZE, firmware)) > 0) {
         if (bytes_read < REPORT_SIZE) {
             fprintf(stderr, "WARNING: Read %zu bytes, expected %d bytes.\n", bytes_read, REPORT_SIZE);
         }
-        checksum += checksum16(buf, bytes_read);
 
         // Capture the last 4 bytes of this buffer for last_chunk
         if (bytes_read >= sizeof(uint32_t)) {
@@ -676,7 +675,6 @@ bool flash(hid_device *dev, long offset, const char *file_name, long fw_size, bo
 
         clear_buffer(buf, REPORT_SIZE);
     }
-    printf("Flashed File Checksum: 0x%04x\n", checksum);
     clear_buffer(buf, REPORT_SIZE);
     fclose(firmware);
 
@@ -782,6 +780,32 @@ bool truncate_and_reopen(const char *file_name, FILE **fp, long new_size) {
     return true;
 }
 
+uint16_t calculate_checksum(FILE *fp, long file_size) {
+    checksum = 0;
+    uint16_t checksum_calc = 0;
+    unsigned char *file_data = malloc(file_size);
+
+    if (file_data == NULL) {
+        fprintf(stderr, "ERROR: Could not allocate memory for file data.\n");
+        return -1;
+    }
+
+    fseek(fp, 0, SEEK_SET);
+
+    // Read the entire file into the allocated buffer
+    if (fread(file_data, 1, file_size, fp) != file_size) {
+        fprintf(stderr, "ERROR: Could not read the entire file.\n");
+        free(file_data);
+        return -1;
+    }
+
+    // Calculate the checksum
+    checksum_calc = checksum16(file_data, file_size);
+
+    free(file_data);
+    return checksum_calc;
+}
+
 long prepare_file_to_flash(const char *file_name, bool flash_jumploader) {
     FILE *fp = fopen(file_name, "rb");
     if (fp == NULL) {
@@ -802,6 +826,15 @@ long prepare_file_to_flash(const char *file_name, bool flash_jumploader) {
     }
     printf("\n");
     printf("File size: %ld bytes\n", file_size);
+
+    uint16_t checksum_calc = calculate_checksum(fp, file_size);
+    if (checksum_calc == -1L) {
+        fclose(fp);
+        return -1;
+    }
+    checksum = checksum_calc;
+    printf("\n");
+    printf("File Checksum: 0x%04x\n", checksum);
 
     // If jumploader is not 0x200 in length, add padded zeroes to file
     if (flash_jumploader && file_size < QMK_OFFSET_DEFAULT) {


### PR DESCRIPTION
Payload needs to be consistent to the HID report size always, or the ISP protocol locks up in an erroneous state.
This means that while a firmware not matching will flash, but subsequent operations will be ignored and error out.
Fix the behavior by padding the file before flashing, regardless if it's a jumploader or firmware.

Closes #10 